### PR TITLE
Only include inLanguage triples for the main language, not e.g. summary language

### DIFF
--- a/sparql/bf-to-schema.rq
+++ b/sparql/bf-to-schema.rq
@@ -257,7 +257,7 @@ WHERE {
     UNION
     {
       ?work bf:language ?language .
-      FILTER NOT EXISTS { ?language bf:part "original" }
+      FILTER NOT EXISTS { ?language bf:part [] }
       OPTIONAL {
         ?language rdf:value ?languageValue .
       }

--- a/test/40_schema.bats
+++ b/test/40_schema.bats
@@ -574,6 +574,13 @@ setup () {
   [ $status -ne 0 ]
 }
 
+@test "Schema.org RDF: not including summary language" {
+  make slices/verkkoaineisto-00608-schema.nt
+  grep -q -F "<http://schema.org/inLanguage> \"eng\"" slices/verkkoaineisto-00608-schema.nt
+  run grep "<http://schema.org/inLanguage> \"fin\"" slices/verkkoaineisto-00608-schema.nt
+  [ $status -ne 0 ]
+}
+
 @test "Schema.org RDF: skipping bad URIs" {
   make slices/kalastusalue-00595-schema.nt
   grep -q 'SYNTAX ERROR, skipping' slices/kalastusalue-00595-schema.log


### PR DESCRIPTION
Currently we get a few too many schema:inLanguage triples for Works, for example based on summary language (041 $b). It is then impossible to see from the schema.org output what is the main language of the work, since all languages are represented the same way.

This PR filters out the non-main languages in the bf-to-schema conversion. If they are needed in the schema.org output, another representation should be defined.